### PR TITLE
Update plan generation logic for arbitrary data alignments

### DIFF
--- a/FFTW3_header_include.pm
+++ b/FFTW3_header_include.pm
@@ -371,15 +371,20 @@ EOF
     $_last_do_double_precision = $do_double_precision;
 
     my $do_inplace = is_same_data( $in, $out );
+    my $in_alignment = get_data_alignment( $in );
+    my $out_alignment = get_data_alignment( $out );
     my $planID = join('_',
                       $thisfunction,
                       $do_double_precision,
                       $do_inplace,
-                      @dims);
+                      @dims,
+                      $in_alignment,
+                      $out_alignment);
+                   print STDERR "Checking for planID=$planID\n";
     if ( !exists $existingPlans{$planID} )
     {
-      $existingPlans{$planID} = compute_plan( \@dims, $do_double_precision, $is_real_fft,
-                                              $do_inverse_fft );
+                   print STDERR "Computing for planID=$planID\n";
+      $existingPlans{$planID} = compute_plan( \@dims, $do_double_precision, $is_real_fft, $do_inverse_fft, $in, $out );
       $_Nplans++;
     }
 

--- a/compute_plan_template.xs
+++ b/compute_plan_template.xs
@@ -82,13 +82,13 @@ OUTPUT:
 
 
 
-bool
+int
 is_same_data( in, out )
   pdl* in
   pdl* out
 CODE:
 {
-  RETVAL = in->data == out->data;
+  RETVAL = (in->data == out->data) ? 1 : 0;
 }
 OUTPUT:
  RETVAL

--- a/t/fftw.t
+++ b/t/fftw.t
@@ -25,6 +25,8 @@ BEGIN
 {
   plan tests => 176;
   use_ok( 'PDL::FFTW3' );
+
+  *PDL::get_data_alignment = \&PDL::FFTW3::get_data_alignment;
 }
 
 use constant approx_eps_double => 1e-8;
@@ -35,6 +37,8 @@ my $Nplans = 0;
 # 1D basic test
 {
   my $x = sequence(10)->cat(sequence(10)**2)->mv(-1,0);
+
+  print STDERR "\$x alignment is " . $x->get_data_alignment . "\n";
 
   # from octave: conj( fft( (0:9) + i* ((0:9).**2) )' )
   my $Xref = pdl( [45.0000000000000,+285.0000000000000],


### PR DESCRIPTION
This adds information on alignment of the pdl->data regions
to the plan generation stage and provides the get_data_alignment()
routine in PDL::FFTW3 to return that value to the perl level.
The code appears to work correctly but the tests fail the
assumptions on whether or not the plan needs to be regenerated
are no longer correct for the fully general implementation.

Note, the current implementation does not support the use of
FFTW_MEASURE for plan generation.  Nor did the original code.
